### PR TITLE
spm_opm_headmodel: Solution to fiducial issue

### DIFF
--- a/spm_opm_create.m
+++ b/spm_opm_create.m
@@ -93,10 +93,10 @@ end
 %- identify potential BIDS Files
 %----------------------------------------------------------------------
 base = strsplit(dataFile,'meg');
-chanFile= fullfile(direc,[base{1},'channels.tsv']);
-megFile= fullfile(direc,[base{1},'meg.json']);
-posFile= spm_select('FPList',direc,[base{1},'positions.tsv']);
-coordFile= fullfile(direc,[base{1},'coordsystem.json']);
+chanFile = fullfile(direc,[base{1},'channels.tsv']);
+megFile = fullfile(direc,[base{1},'meg.json']);
+posFile = spm_select('FPList',direc,[base{1},'positions.tsv']);
+coordFile = fullfile(direc,[base{1},'coordsystem.json']);
 
 %- Check for channel Info
 %--------------------------------------------------------------------------
@@ -153,33 +153,10 @@ catch
                 positions =0;
             end
         catch
-            warning('No position information found')
+            warning('No sensor position information found')
             positions=0;
         end
     end
-end
-
-%- Forward model Check
-%----------------------------------------------------------------------
-subjectSource   = positions & isfield(S,'sMRI');
-subjectNoStruct = positions & S.template == 1;
-
-if subjectSource
-    switch class(S.sMRI)
-        case 'char'
-            forward = 1;
-            template = 0;
-        case 'double'
-            forward         = 1;
-            template        = S.sMRI==1;
-    end
-elseif subjectNoStruct
-    forward         = 1;
-    template        = 1;
-    S.sMRI          = 1;
-else
-    forward             = 0;
-    template            = 0;
 end
 
 %- work out data size
@@ -219,6 +196,7 @@ D = path(D,direc);
 D = chanlabels(D,1:size(D,1),channels.name);
 D = units(D,1:size(D,1),channels.units);
 D = chantype(D,1:size(D,1),channels.type);
+
 %- Overwrite and Save
 %--------------------------------------------------------------------------
 ma = fullfile(direc,[dataFile,'.mat']);
@@ -258,25 +236,7 @@ else
     D.save();
 end
 
-%- Create Meshes
-%--------------------------------------------------------------------------
-if forward
-    %initially used inverse normalised meshes
-    D = spm_eeg_inv_mesh_ui(D,1,S.sMRI,S.meshres);
-    save(D);
-    % then fill in custom meshes(if they exist)
-    args = [];
-    args.D = D;
-    args.scalp = S.scalp;
-    args.cortex = S.cortex;
-    args.iskull = S.iskull;
-    args.oskull = S.oskull;
-    args.template = template;
-    D = opm_customMeshes(args);
-    save(D);
-end
-
-%-Place Sensors  in object
+%-Place sensors in object
 %--------------------------------------------------------------------------
 if positions
     pos = [posOri.Px,posOri.Py,posOri.Pz];
@@ -332,218 +292,38 @@ if positions
     end
 end
 
-
-%- fiducial settings
-%--------------------------------------------------------------------------
-if subjectSource
-    miMat = zeros(3,3);
-    fiMat = zeros(3,3);
-    fid=[];
-    try % to read the coordsystem.json
-        coord = spm_load(S.coordsystem);
-        fiMat(1,:) = coord.HeadCoilCoordinates.coil1;
-        fiMat(2,:) = coord.HeadCoilCoordinates.coil2;
-        fiMat(3,:) = coord.HeadCoilCoordinates.coil3;
-        miMat(1,:) = coord.AnatomicalLandmarkCoordinates.coil1;
-        miMat(2,:) = coord.AnatomicalLandmarkCoordinates.coil2;
-        miMat(3,:) = coord.AnatomicalLandmarkCoordinates.coil3;
-        fid.fid.label = fieldnames(coord.HeadCoilCoordinates);
-        fid.fid.pnt =fiMat;
-        fid.pos= []; % headshape field that is left blank (GRB)
-        M = fid;
-        M.fid.pnt=miMat;
-        M.pnt = D.inv{1}.mesh.fid.pnt;
-    catch
-        try % to find the BIDS coordsystem.json
-            coord = spm_load(coordFile);
-            fiMat(1,:) = coord.HeadCoilCoordinates.coil1;
-            fiMat(2,:) = coord.HeadCoilCoordinates.coil2;
-            fiMat(3,:) = coord.HeadCoilCoordinates.coil3;
-            miMat(1,:) = coord.AnatomicalLandmarkCoordinates.coil1;
-            miMat(2,:) = coord.AnatomicalLandmarkCoordinates.coil2;
-            miMat(3,:) = coord.AnatomicalLandmarkCoordinates.coil3;
-            fid.fid.label = fieldnames(coord.HeadCoilCoordinates);
-            fid.fid.pnt =fiMat;
-            fid.pos= []; % headshape field that is left blank (GRB)
-            M = fid;
-            M.fid.pnt=miMat;
-            M.pnt = D.inv{1}.mesh.fid.pnt;
-        catch % DEFAULT: transform between fiducials and anatomy is identity
-            fid.fid.label = {'nas', 'lpa', 'rpa'}';
-            fid.fid.pnt = D.inv{1}.mesh.fid.fid.pnt(1:3,:); % George O'Neill
-            fid.pos= [];
-            M = fid;
-            M.pnt = D.inv{1}.mesh.fid.pnt; % George O'Neill
-        end
+%- prep for headmodel processing
+%-------------------------------------------------------
+if positions
+    
+    % auto-populate fields for spm_opm_headmodel
+    targets = {'template','sMRI','coordsystem','headshape',...
+        'meshres','iskull','oskull','scalp','cortex','voltype','lead'};
+    args = struct;
+    args.D = D;
+    for ii = 1:numel(targets)
+        args.(targets{ii}) = S.(targets{ii});
     end
+    keyboard
+    
+    
 end
+% if ~isfield(S,'D'); error('please specify a MEEG object!'); end
+% if ~isfield(S,'template');      S.template = 0;             end
+% if ~isfield(S,'sMRI');          S.sMRI = [];                end
+% if ~isfield(S,'coordsystem');   S.coordsystem = [];         end
+% if ~isfield(S,'headshape');     S.headshape = [];           end
+% if ~isfield(S,'meshres');       S.meshres = 1;              end
+% if ~isfield(S,'iskull');        S.iskull = [];              end
+% if ~isfield(S,'oskull');        S.oskull = [];              end
+% if ~isfield(S,'scalp');         S.scalp = [];               end
+% if ~isfield(S,'cortex');        S.cortex = [];              end
+% if ~isfield(S,'voltype');       S.voltype = 'Single Shell'; end
+% if ~isfield(S,'lead');          S.lead = 0;                 end
 
-% If user wants to use the template brain, try to load fiducials from
-% coordsystem.json
-if subjectNoStruct
-    try
-        
-        % check if there is a headshape file and load data/fids from there
-        % otherwise fallback on coordsystem.json
-        if ~isempty(S.headshape)
-            % SPMs native support for polhemus files was ditched a long
-            % time ago, so using fieldTrip as a backend.
-            shape = ft_read_headshape(S.headshape);
-            fid.pnt = shape.pos;
-            
-            % headshape mush be in the same space as sensors!
-            % get the order into nas, lpa, rpa
-            targetOrder = {'nas','lpa','rpa'};
-            for ii = 1:3
-                fidOrder(ii) = find(ismember(lower(shape.fid.label),targetOrder{ii}));
-            end
-            fid.fid.label = targetOrder;
-            fid.fid.pnt = shape.fid.pos(fidOrder,:);
-            
-        else % coordsys.json fallback
-            
-            try
-                coord = spm_load(S.coordsystem);
-            catch
-                coord = spm_load(coordFile);
-            end
-            
-            % These HeadCoilCoordinates (nas,lpa,rpa) are same space as
-            % sensors positions and specified in the coordsystem.json file
-            fiMat(1,:) = coord.HeadCoilCoordinates.coil1;
-            fiMat(2,:) = coord.HeadCoilCoordinates.coil2;
-            fiMat(3,:) = coord.HeadCoilCoordinates.coil3;
-            
-            fid.fid.label = {'nas', 'lpa', 'rpa'}';
-            fid.fid.pnt = fiMat;
-            
-            fid.pnt = []; % headshape field that is left blank,
-            
-        end
-        
-        % Use SPM Template brain template
-        M.fid.label = {'nas', 'lpa', 'rpa'}';
-        M.fid.pnt = D.inv{1}.mesh.fid.fid.pnt(1:3,:);
-        M.fid.pos = []; % headshape field that is left blank (GRB)
-        M.pnt = D.inv{1}.mesh.fid.pnt;
-    catch
-        subjectNoStruct = 0;
-        warning(['Could not load coordinate system - assuming sensor ',...
-            'positions are in the same coordinate as SPM canonical brain']);
-    end
-end
 
-if(template && ~subjectNoStruct) %make
-    fid.fid.label = {'nas', 'lpa', 'rpa'}';
-    fid.fid.pnt = D.inv{1}.mesh.fid.fid.pnt(1:3,:);
-    fid.pos= []; % headshape field that is left blank (GRB)
-    M = fid;
-    M.pnt = D.inv{1}.mesh.fid.pnt;
-end
-
-%- Coregistration
-%--------------------------------------------------------------------------
-if(forward)
-    if(subjectSource||template)
-        D = fiducials(D, fid);
-        save(D);
-        f=fiducials(D);
-        if ~isempty(f.pnt)
-            D = spm_eeg_inv_datareg_ui(D,1,f,M,1);
-        else
-            f.pnt = zeros(0,3);
-            D = spm_eeg_inv_datareg_ui(D,1,f,M,0);
-        end
-    end
-end
-%- Foward  model specification
-%--------------------------------------------------------------------------
-if forward
-    D.inv{1}.forward.voltype = S.voltype;
-    D = spm_eeg_inv_forward(D);
-    spm_eeg_inv_checkforward(D,1,1);
-end
-save(D);
-
-%- Create lead fields
-%--------------------------------------------------------------------------
-if(forward)
-    D.inv{1}.forward.voltype = S.voltype;
-    D = spm_eeg_inv_forward(D);
-    nverts = length(D.inv{1}.forward.mesh.vert);
-    if(S.lead)
-        [L,D] = spm_eeg_lgainmat(D,1:nverts);
-    end
-    spm_eeg_inv_checkforward(D,1,1);
-    save(D);
-end
 fprintf('%-40s: %30s\n','Completed',spm('time'));
 
-
-end
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%                           Custom Meshes                                 %
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function D = opm_customMeshes(S)
-% wrapper for adding custom meshes to MEG object
-% FORMAT D = spm_opm_customMeshes(S)
-%   S               - input structure
-% Fields of S:
-%   S.D             - Valid MEG object         - Default:
-%   S.cortex        - Cortical mesh file       - Default: Use inverse normalised cortical mesh
-%   S.scalp         - Scalp mesh file          - Default: Use inverse normalised scalp mesh
-%   S.oskull        - Outer skull mesh file    - Default: Use inverse normalised outer skull mesh
-%   S.iskull        - Inner skull mesh file    - Default: Use inverse normalised inner skull mesh
-%   S.template      - is mesh in MNI space?    - Default: 0
-% Output:
-%  D           - MEEG object
-%--------------------------------------------------------------------------
-
-%- Default values & argument check
-%--------------------------------------------------------------------------
-if ~isfield(S, 'D'),           error('MEG object needs to be supplied'); end
-if ~isfield(S, 'cortex'),      S.cortex = []; end
-if ~isfield(S, 'scalp'),       S.scalp = []; end
-if ~isfield(S, 'oskull'),      S.oskull = []; end
-if ~isfield(S, 'iskull'),      S.iskull = []; end
-if ~isfield(S, 'template'),    S.template = 0; end
-
-D = S.D;
-if ~isfield(D.inv{1}.mesh,'sMRI')
-    error('MEG object needs to be contain inverse normalised meshes already')
-end
-
-%- add custom scalp and skull meshes if supplied
-%--------------------------------------------------------------------------
-if ~isempty(S.scalp)
-    D.inv{1}.mesh.tess_scalp = S.scalp;
-end
-
-if ~isempty(S.oskull)
-    D.inv{1}.mesh.tess_oskull = S.oskull;
-end
-
-if ~isempty(S.iskull)
-    D.inv{1}.mesh.tess_iskull = S.iskull;
-end
-
-%- add custom cortex and replace MNI cortex with warped cortex
-%--------------------------------------------------------------------------
-if ~isempty(S.cortex)
-    D.inv{1}.mesh.tess_ctx = S.cortex;
-    if(S.template)
-        D.inv{1}.mesh.tess_mni = S.cortex;
-    else
-        defs.comp{1}.inv.comp{1}.def = {D.inv{1}.mesh.def};
-        defs.comp{1}.inv.space = {D.inv{1}.mesh.sMRI};
-        defs.out{1}.surf.surface = {D.inv{1}.mesh.tess_ctx};
-        defs.out{1}.surf.savedir.savesrc = 1;
-        out = spm_deformations(defs);
-        D.inv{1}.mesh.tess_mni  = export(gifti(out.surf{1}), 'spm');
-    end
-end
-save(D);
 
 end
 

--- a/spm_opm_create.m
+++ b/spm_opm_create.m
@@ -36,6 +36,7 @@ spm('FnBanner', mfilename);
 %--------------------------------------------------------------------------
 if ~isfield(S, 'voltype'),     S.voltype = 'Single Shell';  end
 if ~isfield(S, 'meshres'),     S.meshres = 1;               end
+if ~isfield(S, 'sMRI'),        S.sMRI = [];                 end
 if ~isfield(S, 'scalp'),       S.scalp = [];                end
 if ~isfield(S, 'template'),    S.template = 0;              end
 if ~isfield(S, 'cortex'),      S.cortex = [];               end
@@ -46,7 +47,7 @@ if ~isfield(S, 'path'),        S.path = [];                 end
 if ~isfield(S, 'precision'),   S.precision = 'single';      end
 if ~isfield(S, 'lead'),        S.lead = 0;                  end
 if ~isfield(S, 'headshape');   S.headshape = [];            end
-
+if ~isfield(S, 'coordsystem'); S.coordsystem = [];          end
 
 %- identify Binary File
 %----------------------------------------------------------------------
@@ -304,8 +305,12 @@ if positions
     for ii = 1:numel(targets)
         args.(targets{ii}) = S.(targets{ii});
     end
-    keyboard
     
+    if S.lead
+        [D,L] = spm_opm_headmodel(args);
+    else
+        D = spm_opm_headmodel(args);
+    end
     
 end
 % if ~isfield(S,'D'); error('please specify a MEEG object!'); end

--- a/spm_opm_create.m
+++ b/spm_opm_create.m
@@ -313,7 +313,7 @@ if positions
     else
         D = spm_opm_headmodel(args);
     end
-    
+    D.save;
 end
 
 

--- a/spm_opm_create.m
+++ b/spm_opm_create.m
@@ -97,7 +97,9 @@ base = strsplit(dataFile,'meg');
 chanFile = fullfile(direc,[base{1},'channels.tsv']);
 megFile = fullfile(direc,[base{1},'meg.json']);
 posFile = spm_select('FPList',direc,[base{1},'positions.tsv']);
-coordFile = fullfile(direc,[base{1},'coordsystem.json']);
+if isempty(S.coordsystem)
+    S.coordsystem = fullfile(direc,[base{1},'coordsystem.json']);
+end
 
 %- Check for channel Info
 %--------------------------------------------------------------------------
@@ -313,18 +315,6 @@ if positions
     end
     
 end
-% if ~isfield(S,'D'); error('please specify a MEEG object!'); end
-% if ~isfield(S,'template');      S.template = 0;             end
-% if ~isfield(S,'sMRI');          S.sMRI = [];                end
-% if ~isfield(S,'coordsystem');   S.coordsystem = [];         end
-% if ~isfield(S,'headshape');     S.headshape = [];           end
-% if ~isfield(S,'meshres');       S.meshres = 1;              end
-% if ~isfield(S,'iskull');        S.iskull = [];              end
-% if ~isfield(S,'oskull');        S.oskull = [];              end
-% if ~isfield(S,'scalp');         S.scalp = [];               end
-% if ~isfield(S,'cortex');        S.cortex = [];              end
-% if ~isfield(S,'voltype');       S.voltype = 'Single Shell'; end
-% if ~isfield(S,'lead');          S.lead = 0;                 end
 
 
 fprintf('%-40s: %30s\n','Completed',spm('time'));

--- a/spm_opm_headmodel.m
+++ b/spm_opm_headmodel.m
@@ -49,6 +49,15 @@ elseif isnumeric(S.sMRI)
     end
 end
 
+% check whether coordsystem actually exists, as it might have been
+% auto-imported from spm_opm_create
+if ~isempty(S.coordsystem)
+    if ~exist(S.coordststem,'file')
+        warning('coordystem not found');
+        S.coordystem = [];
+    end
+end
+
 % identify what kind of headmodel specification to do, this should result
 % in a mutually exclusive job dictated
 do.nothing              = 0;

--- a/spm_opm_headmodel.m
+++ b/spm_opm_headmodel.m
@@ -1,8 +1,29 @@
 function [D, L] = spm_opm_headmodel(S)
+% Coregister FIL OPM data and option to set up forward model
+% FORMAT D = spm_opm_create(S)
+%   S               - input structure
+% Fields of S:
+%   S.D             - SPM MEEG Object                          - Default: REQUIRED 
+%   S.coordsystem   - coordsystem.json file                    - Default: transform between sensor space and anatomy is identity
+%   S.sMRI          - Filepath to  MRI file                    - Default: no Default
+%   S.template      - Use SPM canonical template               - Default: 0
+%   S.headhape      - .pos file for better template fit        - Default: no Default
+%   S.cortex        - Custom cortical mesh                     - Default: Use inverse normalised cortical mesh
+%   S.scalp         - Custom scalp mesh                        - Default: Use inverse normalised scalp mesh
+%   S.oskull        - Custom outer skull mesh                  - Default: Use inverse normalised outer skull mesh
+%   S.iskull        - Custom inner skull mesh                  - Default: Use inverse normalised inner skull mesh
+%   S.voltype       - Volume conducter Model type              - Default: 'Single Shell'
+%   S.meshres       - mesh resolution(1,2,3)                   - Default: 1
+%   S.lead          - flag to compute lead field               - Default: 0
+% Output:
+%  D           - MEEG object (also written to disk)
+%  L           - Lead field (also written on disk)
+%__________________________________________________________________________
+% Copyright (C) 2018-2022 Wellcome Centre for Human Neuroimaging
 
-% performs all the wonderful things which the headmodel specification job
-% does, but without a whiff of the matlabbatch anywhere near it. Also has
-% some OPM-specific checks and housekeeping.
+% George O'Neill
+% $Id$
+spm('FnBanner', mfilename);
 
 if ~isfield(S,'D'); error('please specify a MEEG object!'); end
 if ~isfield(S,'template');      S.template = 0;             end

--- a/spm_opm_headmodel.m
+++ b/spm_opm_headmodel.m
@@ -1,0 +1,261 @@
+function [D, L] = spm_opm_headmodel(S)
+
+% performs all the wonderful things which the headmodel specification job
+% does, but without a whiff of the matlabbatch anywhere near it. Also has
+% some OPM-specific checks and housekeeping.
+
+if ~isfield(S,'D'); error('please specify a MEEG object!'); end
+if ~isfield(S,'template');      S.template = 0;             end
+if ~isfield(S,'sMRI');          S.sMRI = [];                end
+if ~isfield(S,'coordsystem');   S.coordsystem = [];         end
+if ~isfield(S,'headshape');     S.headshape = [];           end
+if ~isfield(S,'meshres');       S.meshres = 1;              end
+if ~isfield(S,'iskull');        S.iskull = [];              end
+if ~isfield(S,'oskull');        S.oskull = [];              end
+if ~isfield(S,'scalp');         S.scalp = [];               end
+if ~isfield(S,'cortex');        S.cortex = [];              end
+if ~isfield(S,'voltype');       S.voltype = 'Single Shell'; end
+if ~isfield(S,'lead');          S.lead = 0;                 end
+
+D = spm_eeg_load(S.D);
+
+% check if template brain to be used
+if S.template && isempty(S.sMRI)
+    S.sMRI = 1;
+elseif isnumeric(S.sMRI)
+    if S.sMRI
+        S.template = 1;
+    end
+end
+
+% identify what kind of headmodel specification to do, this should result
+% in a mutually exclusive job dictated
+do.nothing              = 0;
+do.fiducials            = 0;    % Just add fiducial field
+do.identity             = 0;    % sensors and MRI are already in same space
+do.coreg                = 0;
+
+if isempty(S.coordsystem) && isempty(S.sMRI)
+    do.nothing = 1;
+elseif ~isempty(S.coordsystem) && isempty(S.sMRI)
+    do.fiducials = 1;
+elseif isempty(S.coordsystem) && ~isempty(S.sMRI)
+    do.identity = 1;
+elseif ~isempty(S.coordsystem) && ~isempty(S.sMRI)
+    do.coreg = 1;
+end
+
+% deal with the nothing job
+if do.nothing
+    fprintf('No files for coregistration supplied, skipping\n')
+end
+
+%- MRI and meshes.
+%--------------------------------------------------------
+if do.identity || do.coreg
+    %initially used inverse normalised meshes
+    D = spm_eeg_inv_mesh_ui(D,1,S.sMRI,S.meshres);
+    save(D);
+    % then fill in custom meshes(if they exist)
+    args = [];
+    args.D = D;
+    args.scalp = S.scalp;
+    args.cortex = S.cortex;
+    args.iskull = S.iskull;
+    args.oskull = S.oskull;
+    args.template = S.template;
+    S.D = opm_customMeshes(args);
+    save(D);
+end
+
+%- MEG Fiducials
+%--------------------------------------------------------
+fid = [];
+if do.fiducials || do.coreg
+    
+    coord = spm_load(S.coordsystem);
+    hnames = fieldnames(coord.HeadCoilCoordinates);
+    fiMat = zeros(numel(hnames),3);
+    for ii = 1:numel(hnames)
+        fiMat(ii,:) = coord.HeadCoilCoordinates.(hnames{ii});
+    end
+    fid.fid.label = hnames;
+    fid.fid.pnt = fiMat;
+    % load in headshape if supplied
+    if isempty(S.headshape)
+        fid.pnt = [];
+    else
+        % SPMs native support for polhemus files was ditched a long
+        % time ago, so using fieldTrip as a backend.
+        shape = ft_read_headshape(S.headshape);
+        fid.pnt = shape.pos;
+    end
+    
+elseif do.identity
+    fprintf('Assuming sensors and MRI are in same space\n')
+    fid.fid.label = {'nas', 'lpa', 'rpa'}';
+    fid.fid.pnt = D.inv{1}.mesh.fid.fid.pnt(1:3,:); % George O'Neill
+    fid.pnt = [];
+end
+
+if ~isempty(fid)
+    D = fiducials(D, fid);
+    save(D);
+end
+
+%- MRI Landmark specification
+%--------------------------------------------------------
+if do.coreg
+    M = [];
+    % check if MRI landmarks are supplied in coordsystem file
+    if isfield(coord,'AnatomicalLandmarkCoordinates')
+        anames = fieldnames(coord.AnatomicalLandmarkCoordinates);
+        % check all fields from hnames are in anames
+        if ~isempty(setdiff(hnames,anames))
+            error(['Some fidcuial coils are not mentioned in '...
+                'the anatomical landmark description. Please '...
+                'check your coordsystem.json file.']);
+        end
+        M.fid.label = hnames;
+        M.fid.pnt = zeros(numel(hnames),3);
+        for ii = 1:numel(hnames)
+            M.fid.pnt(ii,:) = coord.AnatomicalLandmarkCoordinates.(hnames{ii});
+        end
+        M.pnt = [];
+    else
+        fprintf(['Anatomical landmarks not found in coordsystem.json, '...
+            'will use derived fiducials from MRI itself\n']);
+        
+        % try and match up with some common names
+        targets = {'nz','nas','nasion','lpa','rpa'};
+        missing = setdiff(lower(hnames),targets);
+        if ~isempty(missing)
+            warning(['fiducial naming unclear, '...
+                'assuming nas/lpa/rpa ordering']);
+            M.fid.label     = {'nas', 'lpa', 'rpa'}';
+            M.fid.pnt       = D.inv{1}.mesh.fid.fid.pnt(1:3,:);
+            M.pnt           = [];
+        else
+            for ii = 1:numel(hnames)
+                switch find(strcmpi(targets,hnames{ii}))
+                    case {1,2,3}
+                        % nasion
+                        M.fid.label{ii} = 'nas';
+                        M.fid.pnt(ii,:) = D.inv{1}.mesh.fid.fid.pnt(1,:);
+                    case 4
+                        % lpa
+                        M.fid.label{ii} = 'lpa';
+                        M.fid.pnt(ii,:) = D.inv{1}.mesh.fid.fid.pnt(2,:);
+                    case 5
+                        % rpa
+                        M.fid.label{ii} = 'rpa';
+                        M.fid.pnt(ii,:) = D.inv{1}.mesh.fid.fid.pnt(3,:);
+                end
+            end
+        end
+        
+    end
+    
+elseif do.identity
+    
+    M.fid.label     = {'nas', 'lpa', 'rpa'}';
+    M.fid.pnt       = D.inv{1}.mesh.fid.fid.pnt(1:3,:);
+    M.pnt           = [];
+    
+end
+
+%- Registration
+%--------------------------------------------------------
+if do.coreg || do.identity
+    f = fiducials(D);
+    if ~isempty(f.pnt)
+        D = spm_eeg_inv_datareg_ui(D,1,f,M,1);
+    else
+        f.pnt = zeros(0,3);
+        D = spm_eeg_inv_datareg_ui(D,1,f,M,0);
+    end
+end
+
+save(D);
+
+%- Foward model specification / calculation
+%--------------------------------------------------------------------------
+if do.coreg || do.identity
+    
+    D.inv{1}.forward.voltype = S.voltype;
+    D = spm_eeg_inv_forward(D);
+    if(S.lead)
+        nverts = length(D.inv{1}.forward.mesh.vert);
+        [L,D] = spm_eeg_lgainmat(D,1:nverts);
+    end
+    spm_eeg_inv_checkforward(D,1,1);
+end
+save(D);
+
+end
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%                           Custom Meshes                                 %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function D = opm_customMeshes(S)
+% wrapper for adding custom meshes to MEG object
+% FORMAT D = spm_opm_customMeshes(S)
+%   S               - input structure
+% Fields of S:
+%   S.D             - Valid MEG object         - Default:
+%   S.cortex        - Cortical mesh file       - Default: Use inverse normalised cortical mesh
+%   S.scalp         - Scalp mesh file          - Default: Use inverse normalised scalp mesh
+%   S.oskull        - Outer skull mesh file    - Default: Use inverse normalised outer skull mesh
+%   S.iskull        - Inner skull mesh file    - Default: Use inverse normalised inner skull mesh
+%   S.template      - is mesh in MNI space?    - Default: 0
+% Output:
+%  D           - MEEG object
+%--------------------------------------------------------------------------
+
+%- Default values & argument check
+%--------------------------------------------------------------------------
+if ~isfield(S, 'D'),           error('MEG object needs to be supplied'); end
+if ~isfield(S, 'cortex'),      S.cortex = []; end
+if ~isfield(S, 'scalp'),       S.scalp = []; end
+if ~isfield(S, 'oskull'),      S.oskull = []; end
+if ~isfield(S, 'iskull'),      S.iskull = []; end
+if ~isfield(S, 'template'),    S.template = 0; end
+
+D = S.D;
+if ~isfield(D.inv{1}.mesh,'sMRI')
+    error('MEG object needs to be contain inverse normalised meshes already')
+end
+
+%- add custom scalp and skull meshes if supplied
+%--------------------------------------------------------------------------
+if ~isempty(S.scalp)
+    D.inv{1}.mesh.tess_scalp = S.scalp;
+end
+
+if ~isempty(S.oskull)
+    D.inv{1}.mesh.tess_oskull = S.oskull;
+end
+
+if ~isempty(S.iskull)
+    D.inv{1}.mesh.tess_iskull = S.iskull;
+end
+
+%- add custom cortex and replace MNI cortex with warped cortex
+%--------------------------------------------------------------------------
+if ~isempty(S.cortex)
+    D.inv{1}.mesh.tess_ctx = S.cortex;
+    if(S.template)
+        D.inv{1}.mesh.tess_mni = S.cortex;
+    else
+        defs.comp{1}.inv.comp{1}.def = {D.inv{1}.mesh.def};
+        defs.comp{1}.inv.space = {D.inv{1}.mesh.sMRI};
+        defs.out{1}.surf.surface = {D.inv{1}.mesh.tess_ctx};
+        defs.out{1}.surf.savedir.savesrc = 1;
+        out = spm_deformations(defs);
+        D.inv{1}.mesh.tess_mni  = export(gifti(out.surf{1}), 'spm');
+    end
+end
+save(D);
+
+end

--- a/spm_opm_headmodel.m
+++ b/spm_opm_headmodel.m
@@ -52,9 +52,9 @@ end
 % check whether coordsystem actually exists, as it might have been
 % auto-imported from spm_opm_create
 if ~isempty(S.coordsystem)
-    if ~exist(S.coordststem,'file')
-        warning('coordystem not found');
-        S.coordystem = [];
+    if ~exist(S.coordsystem,'file')
+        warning('coordsystem not found');
+        S.coordsystem = [];
     end
 end
 

--- a/spm_opm_headmodel.m
+++ b/spm_opm_headmodel.m
@@ -47,7 +47,7 @@ end
 
 % deal with the nothing job
 if do.nothing
-    fprintf('No files for coregistration supplied, skipping\n')
+    waarning('No files for coregistration supplied, skipping\n')
 end
 
 %- MRI and meshes.
@@ -92,7 +92,7 @@ if do.fiducials || do.coreg
     end
     
 elseif do.identity
-    fprintf('Assuming sensors and MRI are in same space\n')
+    warning('Assuming sensors and MRI are in same space\n')
     fid.fid.label = {'nas', 'lpa', 'rpa'}';
     fid.fid.pnt = D.inv{1}.mesh.fid.fid.pnt(1:3,:); % George O'Neill
     fid.pnt = [];
@@ -123,8 +123,8 @@ if do.coreg
         end
         M.pnt = [];
     else
-        fprintf(['Anatomical landmarks not found in coordsystem.json, '...
-            'will use derived fiducials from MRI itself\n']);
+        warning(['Anatomical landmarks not found in coordsystem.json, '...
+            'will use derived fiducials from MRI itself']);
         
         % try and match up with some common names
         targets = {'nz','nas','nasion','lpa','rpa'};
@@ -134,7 +134,7 @@ if do.coreg
                 'assuming nas/lpa/rpa ordering']);
             M.fid.label     = {'nas', 'lpa', 'rpa'}';
             M.fid.pnt       = D.inv{1}.mesh.fid.fid.pnt(1:3,:);
-            M.pnt           = [];
+            
         else
             for ii = 1:numel(hnames)
                 switch find(strcmpi(targets,hnames{ii}))
@@ -153,6 +153,11 @@ if do.coreg
                 end
             end
         end
+        if isempty(S.headshape)
+            M.pnt           = [];
+        else
+            M.pnt = D.inv{1}.mesh.fid.pnt;
+        end
         
     end
     
@@ -160,7 +165,11 @@ elseif do.identity
     
     M.fid.label     = {'nas', 'lpa', 'rpa'}';
     M.fid.pnt       = D.inv{1}.mesh.fid.fid.pnt(1:3,:);
-    M.pnt           = [];
+    if isempty(S.headshape)
+        M.pnt           = [];
+    else
+        M.pnt = D.inv{1}.mesh.fid.pnt;
+    end
     
 end
 


### PR DESCRIPTION
Now with less bugs. On test script this fails in two places.

```matlab

S               = [];
S.data          = 'meg.bin';
S.coordystem    = 'coordsystem.json';
S.positions     = 'positions.tsv';
S.channels      = 'channels.tsv';
S.template      = 1;
S.meshres       = 3;
D               = spm_opm_create(S);
```

![image](https://user-images.githubusercontent.com/3579812/155571011-9682c94c-58de-4b7f-97f5-7e88260bad9f.png)

The registration is all wrong, but looking at the coordsys file the fiducials in the test data are nonsensical. it would explain why the registration is off. (and also why there are no marked fiducials in the above plot as the fiducials are in the centre of the brain! I propose updating the coordsys file going forward with the true locations.

Test code also fails at 

```matlab
S =[];
D = spm_opm_create(S);
```

I think this is due to the fact all sim code has been removed from `spm_opm_create` a while ago so this will no longer work as expected. Propse this test is removed from the script entirely. 